### PR TITLE
Add weekly order automation skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # amul-order
-Automatically order Lactose free milk from Amul website every week
+
+This project provides a simple Python script to automate ordering Amul lactose free milk once a week from [shop.amul.com](https://shop.amul.com/).
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a `config.yaml` file using the provided template and fill in your credentials, shipping address and card details.
+   **Keep this file secure and do not commit personal information to version control.**
+
+## Running
+
+Execute the scheduler:
+```bash
+python amul_order.py
+```
+The script uses a cron expression defined in `config.yaml` (`schedule.cron`) to determine when to place the order. By default it runs every Monday at 9 AM.
+
+The HTTP endpoints used here are placeholders. You may need to update them according to the actual API offered by Amul.

--- a/amul_order.py
+++ b/amul_order.py
@@ -1,0 +1,108 @@
+from croniter import croniter
+import time
+import yaml
+import requests
+from dataclasses import dataclass, field
+
+CONFIG_PATH = 'config.yaml'
+
+@dataclass
+class Credentials:
+    mobile: str
+    password: str | None = None
+
+@dataclass
+class Address:
+    line1: str
+    line2: str
+    city: str
+    state: str
+    pincode: str
+
+@dataclass
+class CardInfo:
+    number: str
+    expiry: str
+    cvv: str
+
+@dataclass
+class Config:
+    credentials: Credentials
+    address: Address
+    card: CardInfo
+    sku_url: str
+    cron: str = '0 9 * * MON'
+
+    @staticmethod
+    def from_dict(data: dict) -> 'Config':
+        creds = Credentials(**data['credentials'])
+        addr = Address(**data['address'])
+        card = CardInfo(**data['card'])
+        cron = data.get('schedule', {}).get('cron', '0 9 * * MON')
+        return Config(credentials=creds, address=addr, card=card, sku_url=data['sku_url'], cron=cron)
+
+
+def load_config() -> Config:
+    with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+    return Config.from_dict(data)
+
+
+def login(session: requests.Session, creds: Credentials) -> bool:
+    """Attempt login using mobile credentials. Placeholder for actual API."""
+    payload = {'mobile': creds.mobile}
+    if creds.password:
+        payload['password'] = creds.password
+    resp = session.post('https://shop.amul.com/api/login', json=payload)
+    return resp.ok
+
+
+def add_to_cart(session: requests.Session, sku_url: str) -> bool:
+    """Add the SKU to the cart. Placeholder for actual API call."""
+    resp = session.post('https://shop.amul.com/api/cart/add', json={'sku_url': sku_url, 'qty': 1})
+    return resp.ok
+
+
+def checkout(session: requests.Session, address: Address, card: CardInfo) -> bool:
+    """Perform checkout with saved address and card info. Placeholder for actual API."""
+    data = {
+        'address': address.__dict__,
+        'card': card.__dict__,
+    }
+    resp = session.post('https://shop.amul.com/api/checkout', json=data)
+    return resp.ok
+
+
+def process_order():
+    config = load_config()
+    session = requests.Session()
+    if not login(session, config.credentials):
+        print('Login failed')
+        return
+    if not add_to_cart(session, config.sku_url):
+        print('Add to cart failed')
+        return
+    if not checkout(session, config.address, config.card):
+        print('Checkout failed')
+        return
+    print('Order placed successfully')
+
+
+
+import datetime
+
+def main():
+    config = load_config()
+    base = datetime.datetime.now()
+    cron = croniter(config.cron, base)
+    next_run = cron.get_next(datetime.datetime)
+    print(f"Scheduler started with cron: {config.cron}")
+    while True:
+        now = datetime.datetime.now()
+        if now >= next_run:
+            process_order()
+            next_run = cron.get_next(datetime.datetime)
+        time.sleep(30)
+
+if __name__ == "__main__":
+    main()

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,16 @@
+credentials:
+  mobile: "YOUR_MOBILE_NUMBER"
+  password: "YOUR_PASSWORD"  # or provide token/OTP externally
+address:
+  line1: "B-16, Satyawati colony"
+  line2: "ashok vihar phase 3"
+  city: "Delhi"
+  state: "Delhi"
+  pincode: "110052"
+card:
+  number: "1111222233334444"
+  expiry: "12/28"
+  cvv: "123"
+sku_url: "https://shop.amul.com/en/product/amul-lactose-free-milk-250-ml-or-pack-of-32"
+schedule:
+  cron: "0 9 * * MON"  # every Monday at 9 AM

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+PyYAML
+croniter


### PR DESCRIPTION
## Summary
- add a placeholder script to login and order the Amul SKU
- store credentials and scheduling info in `config.yaml`
- document setup and usage in README
- add a requirements file

## Testing
- `python -m py_compile amul_order.py`
- `python amul_order.py` *(fails: ModuleNotFoundError: No module named 'croniter')*

------
https://chatgpt.com/codex/tasks/task_e_6859231419f88322af15583b7ee811f7